### PR TITLE
feat: add support for OpenSearch XML

### DIFF
--- a/src/js/content/utils.js
+++ b/src/js/content/utils.js
@@ -37,6 +37,7 @@ export function getPageRSS() {
 
         // links
         const types = [
+            'application/opensearchdescription+xml',
             'application/rss+xml',
             'application/atom+xml',
             'application/rdf+xml',


### PR DESCRIPTION
Some website or blog/blog themes support this format.

It looks like a trail of an earlier internet development but is still be used by a few website/blog/blog themes.

For more detail, please visit: https://github.com/dewitt/opensearch

---

I submit this PR because that's the format that my blog theme supports.

Please see more info below:
http://aetherwu.com/  #in source file

or its theme repo:
https://github.com/JeremyFan/hexo-theme-still/blob/db78bdd5e6e0bcd54da719b75e6ce2e73181f655/layout/partial/head.pug

I think the author of this theme has chosen this format for a considerable reason.
I would also open an issue for this theme to discuss possible support for other common formats.