### PR TITLE
fix: remove duplicate entry from link elements

### DIFF
--- a/src/js/content/utils.js
+++ b/src/js/content/utils.js
@@ -61,8 +61,10 @@ export function getPageRSS() {
                         title: links[i].getAttribute('title') || defaultTitle,
                         image,
                     };
-                    pageRSS.push(feed);
-                    unique.save(feed.url);
+                    if (!unique.check(feed.url)) {
+                        pageRSS.push(feed);
+                        unique.save(feed.url);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #196