### PR TITLE
fix(deps) mini-css-extract-plugin loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,7 +70,12 @@ module.exports = {
                 test: /\.css$/,
                 use: [
                     'vue-style-loader',
-                    MiniCssExtractPlugin.loader,
+                    {
+                        loader: MiniCssExtractPlugin.loader,
+                        options: {
+                            esModule: false,
+                        },
+                    },
                     {
                         loader: 'css-loader',
                         options: {
@@ -91,7 +96,12 @@ module.exports = {
                 test: /\.less$/,
                 use: [
                     'vue-style-loader',
-                    MiniCssExtractPlugin.loader,
+                    {
+                        loader: MiniCssExtractPlugin.loader,
+                        options: {
+                            esModule: false,
+                        },
+                    },
                     {
                         loader: 'css-loader',
                         options: {
@@ -113,7 +123,12 @@ module.exports = {
                 test: /\.scss$/,
                 use: [
                     'vue-style-loader',
-                    MiniCssExtractPlugin.loader,
+                    {
+                        loader: MiniCssExtractPlugin.loader,
+                        options: {
+                            esModule: false,
+                        },
+                    },
                     {
                         loader: 'css-loader',
                         options: {


### PR DESCRIPTION
Close #632 

新版 mini-css-extract-plugin 无法以ES Module的方式加载CSS

https://stackoverflow.com/questions/65359841/uncaught-typeerror-cannot-read-property-locals-of-undefined