### PR TITLE
实现safari extension功能，但是不能更新规则

### DIFF
--- a/src/assets/manifest.json
+++ b/src/assets/manifest.json
@@ -36,6 +36,7 @@
         "storage",
         "notifications",
         "alarms",
-        "idle"
+        "idle",
+        "unlimitedStorage"
     ]
 }

--- a/src/js/background/utils.js
+++ b/src/js/background/utils.js
@@ -45,11 +45,13 @@ chrome.alarms.onAlarm.addListener((alarm) => {
     }
 });
 
-chrome.idle.onStateChanged.addListener((newState) => {
-    if (newState === 'active') {
-        initSchedule();
-    }
-});
+if ('idle' in chrome) {
+    chrome.idle.onStateChanged.addListener((newState) => {
+        if (newState === 'active') {
+            initSchedule();
+        }
+    });
+}
 
 getConfig((conf) => {
     config = conf;

--- a/src/js/common/config.js
+++ b/src/js/common/config.js
@@ -26,7 +26,7 @@ export const defaultConfig = {
         local: false,
     },
     refreshTimeout: 5 * 60 * 60,
-    enableRemoteRules: !navigator.userAgent.match(/firefox/i),
+    enableRemoteRules: !navigator.userAgent.match(/firefox|safari/i),
 };
 
 export function getConfig(success) {

--- a/src/js/common/radar-rules.js
+++ b/src/js/common/radar-rules.js
@@ -1,4 +1,4 @@
-({
+export const defaultRules = {
     '8world.com': { _name: '8视界', '.': [{ title: '分类', docs: 'https://docs.rsshub.app/new-media.html#_8-shi-jie-fen-lei', source: ['/:category', '/'], target: '/8world/:category?' }] },
     'aamacau.com': { _name: '論盡媒體 AllAboutMacau Media', '.': [{ title: '话题', docs: 'https://docs.rsshub.app/new-media.html#lun-jin-mei-ti-allaboutmacau-media-hua-ti', source: ['/'], target: '/:category?/:id?' }] },
     'eprice.com.tw': { _name: 'ePrice', '.': [{ title: 'ePrice 比價王', docs: 'https://docs.rsshub.app/new-media.html#eprice', source: ['/'], target: '/:region?' }] },
@@ -1327,4 +1327,4 @@
     },
     'macwk.com': { _name: 'MacWk', '.': [{ title: '应用更新', docs: 'https://docs.rsshub.app/program-update.html#macwk', source: '/soft/:name', target: '/macwk/soft/:name' }] },
     'zyshow.net': { www: [{ title: '', docs: 'https://docs.rsshub.app/game.html#lv-fa-shi-ying-di', source: '/:name/', target: '/zyshow/:name' }] },
-});
+};

--- a/src/js/common/rules.js
+++ b/src/js/common/rules.js
@@ -1,5 +1,5 @@
 import { defaultConfig } from './config';
-import defaultRules from './radar-rules';
+import { defaultRules } from './radar-rules';
 
 export function refreshRules(success) {
     if (defaultConfig.enableRemoteRules) {


### PR DESCRIPTION
使用Xcode的safari-web-extension-converter将RSSHub-Radar转换为safari插件，并且针对safari的兼容性进行了一些修改。在safari中该插件可以正常运行。
编译方法：
1. 使用yarn或者npm编译得到dist目录。
2. 使用`xcrun safari-web-extension-converter ./RSSHub-Radar/dist`创建Xcode工程。
3. 在Xcode中编译safari web extension。
4. 打开safari开发菜单，打开“允许未签名的扩展”，即可启用RSSHub-Radar。

**插件转换的细节可以参考** [链接](https://developer.apple.com/documentation/safariservices/safari_web_extensions/converting_a_web_extension_for_safari)

已知限制：
由于safari不支持sandbox,所以无法实现规则自动更新。