### PR TITLE
fix(config): remote rules on Chromium disabled

### DIFF
--- a/src/js/common/config.js
+++ b/src/js/common/config.js
@@ -26,7 +26,13 @@ export const defaultConfig = {
         local: false,
     },
     refreshTimeout: 5 * 60 * 60,
-    enableRemoteRules: !navigator.userAgent.match(/firefox|safari/i),
+    // typical UA:
+    //   Firefox: Mozilla/5.0 (X11; Linux x86_64; rv:99.0) Gecko/20100101 Firefox/99.0
+    //   Chromium/Chrome: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.88 Safari/537.36
+    //   Some Chromium: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/80.0.3987.87 Chrome/80.0.3987.87 Safari/537.36
+    //   Safari: Mozilla/5.0 (Macintosh; Intel Mac OS X 12_3_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.3 Safari/605.1.15
+    //   Edge: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36 Edg/99.0.1150.36
+    enableRemoteRules: !(navigator.userAgent.match(/firefox/i) || (navigator.userAgent.match(/safari/i) && !navigator.userAgent.match(/chrome/i))),
 };
 
 export function getConfig(success) {

--- a/src/js/options/views/Setting.vue
+++ b/src/js/options/views/Setting.vue
@@ -24,11 +24,11 @@
                 </div>
                 <div class="subtitle">规则更新</div>
                 <div class="setting-item">
-                    <div class="setting-name" v-if="config.enableRemoteRules">我会自动更新，你也可以</div>
-                    <div class="setting-input" v-if="config.enableRemoteRules">
+                    <div class="setting-name" v-if="defaultConfig.enableRemoteRules">我会自动更新，你也可以</div>
+                    <div class="setting-input" v-if="defaultConfig.enableRemoteRules">
                         <el-button style="width: 98px" size="medium" @click="refreshRu" :disabled="refreshDisabled">{{ refreshDisabled ? '更新中' : '立即更新' }}</el-button><el-progress :text-inside="true" :stroke-width="20" :percentage="percentage"></el-progress><span class="time">{{ time }}前更新，{{ leftTime }}后自动更新</span>
                     </div>
-                    <div class="setting-name" v-if="!config.enableRemoteRules">远程更新被禁用</div>
+                    <div class="setting-name" v-if="!defaultConfig.enableRemoteRules">远程更新被禁用</div>
                 </div>
                 <div class="subtitle">一键订阅</div>
                 <div class="setting-item">


### PR DESCRIPTION
https://github.com/DIYgod/RSSHub-Radar/pull/678#discussion_r851613314

https://github.com/DIYgod/RSSHub-Radar/issues/692#issuecomment-1103447465

> Whether remote rules along with local-customized rules are enabled is totally up to UA; however, whether the update button to display is up to a synced variable. That is, if someone builds their own add-on without patches and installs, that variable will be set to `false`, applying patches then installing again will not update that variable to enable the update button. If you do clean your synced variables and build the `master` branch and install it, you will face exactly the same embarrassing situation.