### PR TITLE
popup页面添加「订阅到check酱」按钮，支持一键添加RSS

### DIFF
--- a/src/css/popup.less
+++ b/src/css/popup.less
@@ -148,6 +148,16 @@ body {
             }
         }
 
+        &.rss-submitto-checkchan {
+            color: #f28f34;
+            border: 1px solid #f28f34;
+
+            &:hover {
+                color: #fff;
+                background: #f28f34;
+            }
+        }
+
         &.rss-submitto-miniflux {
             color: #33995b;
             border: 1px solid #33995b;

--- a/src/js/common/config.js
+++ b/src/js/common/config.js
@@ -11,6 +11,8 @@ export const defaultConfig = {
     submitto: {
         ttrss: false,
         ttrssDomain: '',
+        checkchan: false,
+        checkchanBase: '',
         miniflux: false,
         minifluxDomain: '',
         freshrss: false,

--- a/src/js/options/views/Setting.vue
+++ b/src/js/options/views/Setting.vue
@@ -32,6 +32,11 @@
                 </div>
                 <div class="subtitle">{{ $i18n.t('one-click subscription') }}</div>
                 <div class="setting-item">
+                    <div class="setting-name">Check酱<a target="_blank" href="https://ckc.ftqq.com"><i class="el-icon-info"></i></a></div>
+                    <div class="setting-input">
+                        <el-checkbox @change="saveConfig" v-model="config.submitto.checkchan">{{ $i18n.t('enable') }}</el-checkbox>
+                        <el-input @change="saveConfig" style="margin-left: 20px;" v-if="config.submitto.checkchan" v-model="config.submitto.checkchanBase" :placeholder="$i18n.t('required extension base URI', {service: 'CheckChan'})"></el-input>
+                    </div>
                     <div class="setting-name">Tiny Tiny RSS <a target="_blank" href="https://ttrss.henry.wang/zh/"><i class="el-icon-info"></i></a></div>
                     <div class="setting-input">
                         <el-checkbox @change="saveConfig" v-model="config.submitto.ttrss">{{ $i18n.t('enable') }}</el-checkbox>

--- a/src/js/popup/index.js
+++ b/src/js/popup/index.js
@@ -92,8 +92,8 @@ chrome.tabs.query(
     },
     (tabs) => {
         const tabId = tabs[0].id;
-        title = tabs[0].title;
-        favicon = tabs[0].favIconUrl;
+        title = tabs[0].title || '';
+        favicon = tabs[0].favIconUrl || '/favicon.ico';
         getConfig((conf) => {
             config = conf;
             chrome.runtime.sendMessage(

--- a/src/js/popup/index.js
+++ b/src/js/popup/index.js
@@ -7,6 +7,8 @@ import aboutIcon from '../../svg/about.svg';
 import MD5 from 'md5.js';
 
 let config;
+let favicon;
+let title;
 
 function generateList(type, list) {
     let result = '';
@@ -31,6 +33,13 @@ function generateList(type, list) {
                     item.isDocs
                         ? `<a href="${url}" class="rss-action">${i18n.t('documentation')}</a>`
                         : `<div class="rss-action rss-copy" data-clipboard-text="${url}">${i18n.t('copy')}</div>
+                ${
+                    config.submitto.checkchan && config.submitto.checkchanBase
+                        ? `<a href="${config.submitto.checkchanBase.replace(/\/$/, '')}/index.html#/check/add?title=${encodeURI(title)}&url=${encodeURI(url)}&type=rss&icon=${encodeURI(
+                              favicon
+                          )}" class="rss-action rss-submitto-checkchan">${i18n.t('subscribe to')} CheckChan</a>`
+                        : ''
+                }
                 ${
                     config.submitto.ttrss && config.submitto.ttrssDomain
                         ? `<a href="${config.submitto.ttrssDomain.replace(/\/$/, '')}/public.php?op=bookmarklets--subscribe&feed_url=${encodeURI(url)}" class="rss-action rss-submitto-ttrss">${i18n.t('subscribe to')} TTRSS</a>`
@@ -83,7 +92,8 @@ chrome.tabs.query(
     },
     (tabs) => {
         const tabId = tabs[0].id;
-
+        title = tabs[0].title;
+        favicon = tabs[0].favIconUrl;
         getConfig((conf) => {
             config = conf;
             chrome.runtime.sendMessage(

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -24,6 +24,7 @@
   "notifications and reminders": "Notifications and reminders",
   "required access key": "Required, please enter the correct access key",
   "required address": "Required. Please enter you %{service} address",
+  "required extension base URI": "Required. Please enter the %{service} extension URL after installation",
   "requires reader support": "Requires reader support, such as Reeder, etc.",
   "rss not found": "No RSS found",
   "rsshub radar options": "RSSHub Radar Options",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -24,6 +24,7 @@
   "one-click subscription": "Subscripción mediante un click",
   "required access key": "Obligatorio, por favor introduct la clave de acceso correcta",
   "required address": "Obligatorio. Por favor introduce tu dirección %{service}",
+  "required extension base URI": "Obligatorio. Ingrese la URL de la extensión %{service} después de la instalación",
   "requires reader support": "Necesita tener un visor como Reeder o algo del estilo instalado ",
   "rss not found": "No se han encontrado RSS's",
   "rsshub radar options": "RSSHub Radar Configuración",

--- a/src/translations/eu.json
+++ b/src/translations/eu.json
@@ -24,6 +24,7 @@
   "notifications and reminders": "Jakinarazpenak",
   "required access key": "Nahitaezkoa, mesedez sartu sarrera-gako zuzena",
   "required address": "Nahitaezkoa. Mesedez sartu zure %{service} helbidea",
+  "required extension base URI": "Nahitaezkoa. Sartu %{service} luzapenaren URLa instalatu ondoren",
   "requires reader support": "Reeder edo horrelakoren baten moduko irakurgailua behar du",
   "rss not found": "Ez da RSSrik aurkitu",
   "rsshub radar options": "RSSHub Radar Aukerak",

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -24,6 +24,7 @@
     "notifications and reminders": "Notificações e lembretes",
     "required access key": "Obrigatório, por favor insira a chave de acesso correta",
     "required address": "Obrigatório. Por favor insira o seu endereço de %{service}",
+    "required extension base URI": "Obrigatório. Insira o URL da extensão %{service} após a instalação",
     "requires reader support": "Requer suporte a leitor, tais como Reeder, etc.",
     "rss not found": "Nenhuma RSS encontrada",
     "rsshub radar options": "Opções RSSHub Radar",

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -23,6 +23,7 @@
   "notifications and reminders": "通知与提醒",
   "one-click subscription": "一键订阅",
   "required address": "必填，请输入你的 %{service} 地址",
+  "required extension base URI": "必填，请输入你安装完成后的%{service}插件地址",
   "required access key": "必填，请输入正确的访问密钥",
   "requires reader support": "需要阅读器支持，如 Reeder 等",
   "rss not found": "当前页面没有检测到 RSS",


### PR DESCRIPTION
Check酱( ckc.ftqq.com )是一个基于浏览器插件的免费监测工具，可以监测网页和RSS，并发送通知、生成变动信息流。这个PR为[RSSHub-Radar](https://github.com/DIYgod/RSSHub-Radar) 添加了一个按钮，用于快速跳转到Check酱插件的监测任务添加页面，并自动填入对应的内容。