### PR TITLE
fix: no page rss in some page

### DIFF
--- a/src/js/sandbox/utils.js
+++ b/src/js/sandbox/utils.js
@@ -18,10 +18,15 @@ function ruleHandler(rule, params, url, html, success, fail) {
         }
 
         if (resultWithParams) {
-            const requiredParams = resultWithParams.match(/\/:\w+\??(?=\/|$)/g).map((param) => ({
+            // if no :param in resultWithParams, requiredParams will be null
+            // in that case, just skip the following steps and return resultWithParams
+            const requiredParams = resultWithParams.match(/\/:\w+\??(?=\/|$)/g)?.map((param) => ({
                 name: param.slice(2).replace(/\?$/, ''),
                 optional: param.endsWith('?'),
             }));
+            if (!requiredParams) {
+                return resultWithParams;
+            }
             for (const param of requiredParams) {
                 if (params[param.name]) {
                     // successfully matched


### PR DESCRIPTION
#699 #700

version 1.8.0 will show no page rss in some specific pages.

Below is some examples.

| rule | example page | `rule.target` | show page rss |
| -- | -- | -- | -- |
| [NHK News Web Easy](https://github.com/DIYgod/RSSHub/blob/master/lib/v2/nhk/radar.js) | https://www3.nhk.or.jp/news/easy/ | `/nhk/news_web_easy` | ❌ |
| [Bangumi 萌番组](https://github.com/DIYgod/RSSHub/blob/master/lib/v2/bangumi/radar.js) | https://bangumi.moe/ | `/bangumi` | ❌ |
| [Bilibili 视频评论](https://github.com/DIYgod/RSSHub/blob/master/lib/v2/bilibili/radar.js) | https://www.bilibili.com/video/BV1vA411b7ip | `/bilibili/video/reply/${params.aid.replace('av', '')}` | ❌ |
| [中国知网 期刊](https://github.com/DIYgod/RSSHub/blob/master/lib/v2/cnki/radar.js) | https://navi.cnki.net/knavi/journals/ZGXF/detail | `/cnki/journals/:name` | ✔️ |
| [Twitter 用户时间线](https://github.com/DIYgod/RSSHub/blob/master/lib/v2/twitter/radar.js) | https://twitter.com/Kyutai_X | `/twitter/user/:id` | ✔️ |

Pages with radar rules whose `target` value has no string like `:param` will be affected.

In that case, this line will raise error and entire function will fail, result in no page rss return.

https://github.com/DIYgod/RSSHub-Radar/blob/c75ee89d585439a384cbecc2ba512c7d04029db1/src/js/sandbox/utils.js#L21

This pull request fix it.