### PR TITLE
Polyfill modules for rssParser

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "https-browserify": "^1.0.0",
     "i18n-js": "^4.2.2",
     "md5.js": "^1.3.5",
+    "process": "^0.11.10",
     "psl": "1.9.0",
     "route-recognizer": "0.3.4",
     "rss-parser": "3.12.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = {
             "url": require.resolve("url/"),
             "https": require.resolve("https-browserify"),
             "timers": require.resolve("timers-browserify"),
+            "process": require.resolve("process/browser"),
         }
     },
 
@@ -200,6 +201,10 @@ module.exports = {
         new VueLoaderPlugin(),
         new webpack.DefinePlugin({
             VERSION: JSON.stringify(require('./src/assets/manifest.json').version)
+        }),
+        new webpack.ProvidePlugin({
+          Buffer: ['buffer', 'Buffer'],
+          process: 'process/browser',
         }),
     ],
 };


### PR DESCRIPTION
Webpack 5 no longer polyfills Node APIs in the browser, rendering `rbren/rss-parser` failed to run in RSSHub.

One can confirm this by adding extra debug output to `handleRSS` function in `js/background/utils.js`:

![debug_code](https://github.com/DIYgod/RSSHub-Radar/assets/54884471/c98ac4be-d0ad-4d29-a4e8-4dbebabb0209)

![original_error](https://github.com/DIYgod/RSSHub-Radar/assets/54884471/f6c1d396-80bc-4195-ba4f-163d88daed97)

