### PR TITLE
fix: add polyfills for rssParser

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "https-browserify": "^1.0.0",
     "i18n-js": "^4.2.2",
     "md5.js": "^1.3.5",
+    "process": "^0.11.10",
     "psl": "1.9.0",
     "route-recognizer": "0.3.4",
     "rss-parser": "3.12.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = {
             "url": require.resolve("url/"),
             "https": require.resolve("https-browserify"),
             "timers": require.resolve("timers-browserify"),
+            "process": require.resolve("process/browser"),
         }
     },
 
@@ -200,6 +201,10 @@ module.exports = {
         new VueLoaderPlugin(),
         new webpack.DefinePlugin({
             VERSION: JSON.stringify(require('./src/assets/manifest.json').version)
+        }),
+        new webpack.ProvidePlugin({
+          Buffer: ['buffer', 'Buffer'],
+          process: 'process/browser',
         }),
     ],
 };


### PR DESCRIPTION
Webpack 5 no longer polyfills Node APIs in the browser, rendering `rbren/rss-parser` failed to run in RSSHub.

One can confirm this by adding extra debug output to function `handleRSS`  in `js/background/utils.js`:

![debug_code](https://github.com/DIYgod/RSSHub-Radar/assets/54884471/eb2d6da2-a7a3-4edd-ac6b-faf672fff958)

![original_error](https://github.com/DIYgod/RSSHub-Radar/assets/54884471/edcf8d2d-4b75-4e97-abf3-d67d0f0adc3d)
