### PR TITLE
fix: detect rss links with trailing slash

### DIFF
--- a/src/js/content/utils.js
+++ b/src/js/content/utils.js
@@ -71,7 +71,7 @@ export function getPageRSS() {
                 const href = aEles[i].getAttribute('href');
 
                 if (
-                    href.match(/\/(feed|rss|atom)(\.(xml|rss|atom))?$/) ||
+                    href.match(/\/(feed|rss|atom)(\.(xml|rss|atom))?\/?$/) ||
                     (aEles[i].hasAttribute('title') && aEles[i].getAttribute('title').match(check)) ||
                     (aEles[i].hasAttribute('class') && aEles[i].getAttribute('class').match(check)) ||
                     (aEles[i].innerText && aEles[i].innerText.match(check))


### PR DESCRIPTION
For example, the RSS feed at https://slykiten.com/feed/ for the website https://slykiten.com/ is currently not detected.

Regex: https://regex101.com/r/s8zU8z/1

Please note that this fix requires #735 to be merged beforehand, as the rss parser is completely broken for now.