### PR TITLE
perf(deps): replace `psl` with `tldts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "lucide-react": "^0.302.0",
     "md5.js": "^1.3.5",
     "plasmo": "0.84.0",
-    "psl": "^1.9.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hot-toast": "^2.4.1",
@@ -36,6 +35,7 @@
     "rss-parser": "3.13.0",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
+    "tldts": "^6.1.1",
     "usehooks-ts": "^2.9.1",
     "xss": "1.0.14"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ dependencies:
   plasmo:
     specifier: 0.84.0
     version: 0.84.0(lodash@4.17.21)(postcss@8.4.32)(react-dom@18.2.0)(react@18.2.0)
-  psl:
-    specifier: ^1.9.0
-    version: 1.9.0
   react:
     specifier: 18.2.0
     version: 18.2.0
@@ -77,6 +74,9 @@ dependencies:
   tailwindcss-animate:
     specifier: ^1.0.7
     version: 1.0.7(tailwindcss@3.4.0)
+  tldts:
+    specifier: ^6.1.1
+    version: 6.1.1
   usehooks-ts:
     specifier: ^2.9.1
     version: 2.9.1(react-dom@18.2.0)(react@18.2.0)
@@ -5881,10 +5881,6 @@ packages:
     dev: false
     optional: true
 
-  /psl@1.9.0:
-    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
-    dev: false
-
   /pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
     dependencies:
@@ -6519,6 +6515,17 @@ packages:
 
   /timsort@0.3.0:
     resolution: {integrity: sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==}
+    dev: false
+
+  /tldts-core@6.1.1:
+    resolution: {integrity: sha512-xBHFfOO2YmEwogupGTKR0IBXe1IJe1/GleNeXpO294Fk90aQSvrop41BKA66CkfNLVOuomJDZ304KxwovT04Vw==}
+    dev: false
+
+  /tldts@6.1.1:
+    resolution: {integrity: sha512-uV5xEtjR8VdMZZU0my9zLqWJNAkG0PZ5l5t9F1dBYwOyeFeWTFd0emxEs12Y1U39XKD+dF2ElzNU59Qq0Z4PGQ==}
+    hasBin: true
+    dependencies:
+      tldts-core: 6.1.1
     dev: false
 
   /tmp@0.0.33:

--- a/src/lib/rsshub.ts
+++ b/src/lib/rsshub.ts
@@ -1,4 +1,4 @@
-import psl from 'psl';
+import { parse } from 'tldts';
 import RouteRecognizer from 'route-recognizer';
 import { parseRules } from './rules';
 import type { Rule, RSSData } from './types';
@@ -78,7 +78,7 @@ export function getPageRSSHub(data: {
 
     let parsedDomain;
     try {
-        parsedDomain = psl.parse(new URL(url).hostname);
+        parsedDomain = parse(new URL(url).hostname);
     } catch (error) {
         return [];
     }
@@ -186,7 +186,7 @@ export function getWebsiteRSSHub(data: {
     const rules = parseRules(data.rules);
     let parsedDomain;
     try {
-        parsedDomain = psl.parse(new URL(url).hostname);
+        parsedDomain = parse(new URL(url).hostname);
     } catch (error) {
         return [];
     }


### PR DESCRIPTION
It runs [fast and performant](https://remusao.github.io/posts/tldts-benchmarks.html).



<details><summary>Returned object is similar.</summary>

![image](https://github.com/DIYgod/RSSHub-Radar/assets/11386903/281253c6-08e4-446c-bf9d-307c9eaeadfa)
</details>

Background: https://github.com/salesforce/tough-cookie/pull/346