### PR TITLE
fix: apply dark mode at root

### DIFF
--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -3,11 +3,13 @@ import "~/lib/style.css"
 import { Toaster } from "react-hot-toast"
 import { MemoryRouter } from "react-router-dom"
 
+import { useDark } from "~/lib/hooks/use-dark"
 import { Routing } from "~/options/routes"
 
 import Siderbar from "./Siderbar"
 
 function Options() {
+  useDark()
   return (
     <div className="max-w-screen-lg mx-auto text-base py-10 px-4">
       <Toaster

--- a/src/tabs/preview.tsx
+++ b/src/tabs/preview.tsx
@@ -14,12 +14,15 @@ import {
   CardHeader,
   CardTitle,
 } from "~/lib/components/Card"
+import { useDark } from "~/lib/hooks/use-dark"
 import { fetchRSSContent } from "~/lib/utils"
 import RSSItem from "~/popup/RSSItem"
 
 const parser = new Parser()
 
 function PreviewPage() {
+  useDark()
+
   const url = new URLSearchParams(window.location.search).get("url")
 
   const [parsed, setParsed] = useState<


### PR DESCRIPTION
Before this fix, only after we open the sidebar, the dark mode can be applied

![ScreenShot 2024-02-23 19 09 48](https://github.com/DIYgod/RSSHub-Radar/assets/38493346/4b09f965-8776-4a58-b571-2ef69e468509)

I do not know why the script in [index.html](https://docs.plasmo.com/framework/customization/html) does not work, so I use `useDark` at the entry
