### PR TITLE
feat: allow disable update notification

### DIFF
--- a/assets/locales/en/messages.json
+++ b/assets/locales/en/messages.json
@@ -71,6 +71,9 @@
   "localReader": {
     "message": "Local reader"
   },
+  "updateNotification": {
+    "message": "Update notification"
+  },
   "notificationsAndReminders": {
     "message": "Badge reminder"
   },

--- a/assets/locales/zh_CN/messages.json
+++ b/assets/locales/zh_CN/messages.json
@@ -71,6 +71,9 @@
   "localReader": {
     "message": "本地阅读器"
   },
+  "updateNotification": {
+    "message": "更新通知"
+  },
   "notificationsAndReminders": {
     "message": "角标提醒"
   },

--- a/package.json
+++ b/package.json
@@ -75,8 +75,10 @@
       "tabs",
       "offscreen",
       "storage",
-      "notifications",
       "alarms"
+    ],
+    "optional_permissions": [
+      "notifications"
     ],
     "browser_specific_settings": {
       "gecko": {

--- a/src/background/update-notifications.ts
+++ b/src/background/update-notifications.ts
@@ -2,6 +2,8 @@ import RSSHubIcon from "data-base64:~/assets/icon.png"
 
 import { Storage } from "@plasmohq/storage"
 
+import { getConfig } from "~/lib/config"
+
 import info from "../../package.json"
 
 const storage = new Storage({
@@ -10,23 +12,24 @@ const storage = new Storage({
 
 export const initUpdateNotifications = async () => {
   const version = await storage.get("version")
-  if (!version || version !== info.version) {
-    chrome.notifications?.create("RSSHubRadarUpdate", {
-      type: "basic",
-      iconUrl: RSSHubIcon,
-      title: version
-        ? chrome.i18n.getMessage("extensionUpdateTip")
-        : chrome.i18n.getMessage("extensionInstallTip"),
-      message: `v${info.version}, ${chrome.i18n.getMessage("clickToViewChangeLog")}`,
-    })
-    chrome.notifications?.onClicked.addListener((id) => {
-      if (id === "RSSHubRadarUpdate") {
-        chrome.tabs.create({
-          url: "https://github.com/DIYgod/RSSHub-Radar/releases",
-        })
-        chrome.notifications?.clear("RSSHubRadarUpdate")
-      }
-    })
-    await storage.set("version", info.version)
-  }
+  const { updateNotification } = await getConfig()
+  if (!updateNotification || version === info.version) return
+
+  chrome.notifications?.create("RSSHubRadarUpdate", {
+    type: "basic",
+    iconUrl: RSSHubIcon,
+    title: version
+      ? chrome.i18n.getMessage("extensionUpdateTip")
+      : chrome.i18n.getMessage("extensionInstallTip"),
+    message: `v${info.version}, ${chrome.i18n.getMessage("clickToViewChangeLog")}`,
+  })
+  chrome.notifications?.onClicked.addListener((id) => {
+    if (id === "RSSHubRadarUpdate") {
+      chrome.tabs.create({
+        url: "https://github.com/DIYgod/RSSHub-Radar/releases",
+      })
+      chrome.notifications?.clear("RSSHubRadarUpdate")
+    }
+  })
+  await storage.set("version", info.version)
 }

--- a/src/background/update-notifications.ts
+++ b/src/background/update-notifications.ts
@@ -2,8 +2,6 @@ import RSSHubIcon from "data-base64:~/assets/icon.png"
 
 import { Storage } from "@plasmohq/storage"
 
-import { getConfig } from "~/lib/config"
-
 import info from "../../package.json"
 
 const storage = new Storage({
@@ -12,8 +10,7 @@ const storage = new Storage({
 
 export const initUpdateNotifications = async () => {
   const version = await storage.get("version")
-  const { updateNotification } = await getConfig()
-  if (!updateNotification || version === info.version) return
+  if (version === info.version) return
 
   chrome.notifications?.create("RSSHubRadarUpdate", {
     type: "basic",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -19,7 +19,6 @@ export const defaultConfig = {
   rsshubAccessControl: {
     accessKey: "",
   },
-  updateNotification: true,
   notice: {
     badge: true,
   },

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -19,6 +19,7 @@ export const defaultConfig = {
   rsshubAccessControl: {
     accessKey: "",
   },
+  updateNotification: true,
   notice: {
     badge: true,
   },

--- a/src/options/routes/General.tsx
+++ b/src/options/routes/General.tsx
@@ -49,6 +49,20 @@ function General() {
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="grid w-full items-center gap-2">
+              <Label htmlFor="updateNotification">
+                {chrome.i18n.getMessage("updateNotification")}
+              </Label>
+              <Switch
+                id="updateNotification"
+                checked={config.updateNotification}
+                onCheckedChange={(value) =>
+                  setConfig({
+                    updateNotification: value,
+                  })
+                }
+              />
+            </div>
+            <div className="grid w-full items-center gap-2">
               <Label htmlFor="notificationsAndReminders">
                 {chrome.i18n.getMessage("notificationsAndReminders")}
               </Label>

--- a/src/options/routes/General.tsx
+++ b/src/options/routes/General.tsx
@@ -37,6 +37,20 @@ function General() {
 
   const [rulesUpdating, setRulesUpdating] = useState(false)
 
+  const [isNotificationPermissionGranted, setIsNotificationPermissionGranted] =
+    useState(false)
+
+  useEffect(() => {
+    chrome.permissions.contains(
+      {
+        permissions: ["notifications"],
+      },
+      (granted) => {
+        setIsNotificationPermissionGranted(granted)
+      },
+    )
+  }, [])
+
   return (
     <div>
       <h1 className="text-3xl font-medium leading-10 mb-6 text-primary border-b pb-4">
@@ -54,12 +68,20 @@ function General() {
               </Label>
               <Switch
                 id="updateNotification"
-                checked={config.updateNotification}
-                onCheckedChange={(value) =>
-                  setConfig({
-                    updateNotification: value,
+                checked={isNotificationPermissionGranted}
+                onCheckedChange={async (value) => {
+                  if (!value) {
+                    await chrome.permissions.remove({
+                      permissions: ["notifications"],
+                    })
+                    setIsNotificationPermissionGranted(false)
+                    return
+                  }
+                  const granted = await chrome.permissions.request({
+                    permissions: ["notifications"],
                   })
-                }
+                  setIsNotificationPermissionGranted(granted)
+                }}
               />
             </div>
             <div className="grid w-full items-center gap-2">

--- a/src/options/routes/General.tsx
+++ b/src/options/routes/General.tsx
@@ -69,18 +69,26 @@ function General() {
               <Switch
                 id="updateNotification"
                 checked={isNotificationPermissionGranted}
-                onCheckedChange={async (value) => {
+                onCheckedChange={(value) => {
                   if (!value) {
-                    await chrome.permissions.remove({
-                      permissions: ["notifications"],
-                    })
-                    setIsNotificationPermissionGranted(false)
+                    chrome.permissions.remove(
+                      {
+                        permissions: ["notifications"],
+                      },
+                      (removed) => {
+                        setIsNotificationPermissionGranted(!removed)
+                      },
+                    )
                     return
                   }
-                  const granted = await chrome.permissions.request({
-                    permissions: ["notifications"],
-                  })
-                  setIsNotificationPermissionGranted(granted)
+                  chrome.permissions.request(
+                    {
+                      permissions: ["notifications"],
+                    },
+                    (granted) => {
+                      setIsNotificationPermissionGranted(granted)
+                    },
+                  )
                 }}
               />
             </div>


### PR DESCRIPTION
close #781 

This PR makes notification permission optional.

The other option is to keep the permission and use storage to indicate whether should we send a notification (In this way, we can set the default option to true, as we can not request permission in the background). You can check the first commit of this PR.

![ScreenShot 2024-02-29 15 53 09](https://github.com/DIYgod/RSSHub-Radar/assets/38493346/111e18a8-a265-4c74-a765-d665a2d1e68a)
