### PR TITLE
fix: 404 links of docs.rsshub.app

### DIFF
--- a/assets/locales/en/messages.json
+++ b/assets/locales/en/messages.json
@@ -111,7 +111,7 @@
     "message": "RSSHub Radar is a spin-off of <a target=\"_blank\" href=\"https://docs.rsshub.app\">RSSHub</a> that helps you quickly discover and subscribe to RSS and RSSHub for your current site, and the project is <a target=\"_blank\" href=\"https://github.com/DIYgod/RSSHub-Radar\">open source</a> under the MIT license and is completely free to use."
   },
   "sponsoredDevelopment": {
-    "message": "⭐️ Sponsor RSSHub Radar: <a target=\"_blank\" href=\"https://docs.rsshub.app/support/\">https://docs.rsshub.app/support/</a>"
+    "message": "⭐️ Sponsor RSSHub Radar: <a target=\"_blank\" href=\"https://docs.rsshub.app/sponsor\">https://docs.rsshub.app/sponsor</a>"
   },
   "updateLog": {
     "message": "📝 Update log"

--- a/assets/locales/en/messages.json
+++ b/assets/locales/en/messages.json
@@ -54,7 +54,7 @@
     "message": "Full remote updates are disabled due to browser limitations"
   },
   "forMoreRulesJoinUs": {
-    "message": "For more rules support, <a target=\"_blank\" href=\"https://docs.rsshub.app/joinus/quick-start.html\">join us</a>！"
+    "message": "For more rules support, <a target=\"_blank\" href=\"https://docs.rsshub.app/joinus/#quick-start\">join us</a>！"
   },
   "general": {
     "message": "General"

--- a/assets/locales/zh_CN/messages.json
+++ b/assets/locales/zh_CN/messages.json
@@ -54,7 +54,7 @@
     "message": "由于浏览器限制，完整的远程更新被禁用"
   },
   "forMoreRulesJoinUs": {
-    "message": "更多规则支持中，快来<a target=\"_blank\" href=\"https://docs.rsshub.app/zh/joinus/quick-start.html\">参与我们</a>吧！"
+    "message": "更多规则支持中，快来<a target=\"_blank\" href=\"https://docs.rsshub.app/zh/joinus/#quick-start\">参与我们</a>吧！"
   },
   "general": {
     "message": "常规"

--- a/assets/locales/zh_CN/messages.json
+++ b/assets/locales/zh_CN/messages.json
@@ -111,7 +111,7 @@
     "message": "RSSHub Radar 是 <a target=\"_blank\" href=\"https://docs.rsshub.app/zh/\">RSSHub</a> 的衍生项目，她可以帮助你快速发现和订阅当前网站的 RSS 和 RSSHub，项目<a target=\"_blank\" href=\"https://github.com/DIYgod/RSSHub-Radar\">采用 MIT 许可开源</a>，使用完全免费。"
   },
   "sponsoredDevelopment": {
-    "message": "⭐️ 赞助 RSSHub Radar 的开发: <a target=\"_blank\" href=\"https://docs.rsshub.app/zh/support/\">https://docs.rsshub.app/zh/support/</a>"
+    "message": "⭐️ 赞助 RSSHub Radar 的开发: <a target=\"_blank\" href=\"https://docs.rsshub.app/zh/sponsor\">https://docs.rsshub.app/zh/sponsor</a>"
   },
   "updateLog": {
     "message": "📝 更新日志"

--- a/src/options/routes/General.tsx
+++ b/src/options/routes/General.tsx
@@ -151,7 +151,7 @@ function General() {
                 <a
                   className="h-[14px] ml-1"
                   target="_blank"
-                  href="https://docs.rsshub.app/install/config#access-keycode"
+                  href="https://docs.rsshub.app/deploy/config#access-control-configurations"
                 >
                   <i className="i-mingcute-question-line"></i>
                 </a>


### PR DESCRIPTION
The old links are 404 errors, so I checked out docs.rsshub.app to update them.

In the `README.md` file at this link: `[See documentation](https://docs.rsshub.app/joinus/new-radar)`, I could not find the corresponding new URL, and the author of `docs.rsshub` needs to supplement and update it.

Appreciate the development team for reviewing my PR.