### PR TITLE
fix: don't encode url for copy, support route param with regex

### DIFF
--- a/src/lib/rsshub.ts
+++ b/src/lib/rsshub.ts
@@ -17,6 +17,13 @@ function ruleHandler(rule: Rule, params, url, html, success, fail) {
       resultWithParams = rule.target
     }
 
+    // clean params with regex requirements
+    // /npm/package/:name{(@[a-z0-9-~][a-z0-9-._~]*/)?[a-z0-9-~][a-z0-9-._~]*} -> /npm/package/:name
+    resultWithParams = resultWithParams.replace(
+      /\/:\w+\{[^}]*\}(?=\/|$)/g,
+      (match) => match.replace(/\{[^}]*\}/, ""),
+    )
+
     if (resultWithParams) {
       // if no :param in resultWithParams, requiredParams will be null
       // in that case, just skip the following steps and return resultWithParams

--- a/src/popup/RSSItem.tsx
+++ b/src/popup/RSSItem.tsx
@@ -43,7 +43,6 @@ function RSSItem({
       chrome.i18n.getMessage("current"),
     )
   }
-  url = encodeURI(url)
   const encodedUrl = encodeURIComponent(url)
 
   return (

--- a/src/popup/RSSItem.tsx
+++ b/src/popup/RSSItem.tsx
@@ -19,7 +19,9 @@ function RSSItem({
   hidePreview?: boolean
 }) {
   const [config, setConfig] = useState(defaultConfig)
-  getConfig().then(setConfig)
+  useEffect(() => {
+    getConfig().then(setConfig)
+  }, [])
   const [_, copy] = useCopyToClipboard()
   const [copied, setCopied] = useState(false)
   useEffect(() => {


### PR DESCRIPTION
1. don't encode url for copy

https://rss-scraper.deno.dev/feed.xml?url=https%3A%2F%2Freact.dev%2Fblog&itemSelector=a&titleSelector=h2

```
original      : https://rss-scraper.deno.dev/feed.xml?url=https%3A%2F%2Freact.dev%2Fblog&itemSelector=a&titleSelector=h2
in copy button: https://rss-scraper.deno.dev/feed.xml?url=https%253A%252F%252Freact.dev%252Fblog&itemSelector=a&titleSelector=h2
```

2. support route param with regex

https://www.npmjs.com/package/eslint-plugin-unused-imports

https://docs.rsshub.app/routes/program-update#npm

```
/npm/package/:name{(@[a-z0-9-~][a-z0-9-._~]*/)?[a-z0-9-~][a-z0-9-._~]*}
```