### PR TITLE
fix: remove useless scroll bar

### DIFF
--- a/src/popup/RSSList.tsx
+++ b/src/popup/RSSList.tsx
@@ -9,7 +9,7 @@ function RSSList({ type, list }: { type: string; list: RSSData[] }) {
   return (
     <div className="space-y-4">
       <h2 className="text-base font-bold">{chrome.i18n.getMessage(type)}</h2>
-      <ul className="overflow-x-auto w-max max-w-[700px]">
+      <ul className="overflow-x-auto w-max min-w-full max-w-[700px]">
         {list.map((item) => (
           <RSSItem key={item.url + item.title} item={item} type={type} />
         ))}

--- a/src/popup/RSSList.tsx
+++ b/src/popup/RSSList.tsx
@@ -9,7 +9,7 @@ function RSSList({ type, list }: { type: string; list: RSSData[] }) {
   return (
     <div className="space-y-4">
       <h2 className="text-base font-bold">{chrome.i18n.getMessage(type)}</h2>
-      <ul className="overflow-x-auto">
+      <ul className="overflow-x-auto w-max max-w-[700px]">
         {list.map((item) => (
           <RSSItem key={item.url + item.title} item={item} type={type} />
         ))}


### PR DESCRIPTION
When we only have one `Quick Subscription`

Before:

![ScreenShot 2024-06-13 23 45 56](https://github.com/DIYgod/RSSHub-Radar/assets/38493346/7854785f-aa35-4dc6-85ad-4d90d5b953cd)

After:

![ScreenShot 2024-06-13 23 47 01](https://github.com/DIYgod/RSSHub-Radar/assets/38493346/1d0ac434-58bf-4c69-a979-e76a4aca3150)

This also work for multiple items:

![ScreenShot 2024-06-13 23 47 32](https://github.com/DIYgod/RSSHub-Radar/assets/38493346/de91d513-4124-4b52-91f5-cbf593e86216)

![ScreenShot 2024-06-13 23 48 37](https://github.com/DIYgod/RSSHub-Radar/assets/38493346/b9516750-830a-4f5a-9833-ff790e365d64)

![ScreenShot 2024-06-13 23 51 07](https://github.com/DIYgod/RSSHub-Radar/assets/38493346/c415e7f4-1227-4b14-b490-ff462f2e4af8)
