### PR TITLE
feat(settings): add access key format configuration option

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -8,6 +8,9 @@
   "accessKey": {
     "message": "Access key"
   },
+  "accessKeyType": {
+    "message": "Access key format"
+  },
   "clickToSet": {
     "message": "Click to set"
   },

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -8,6 +8,9 @@
   "accessKey": {
     "message": "访问密钥"
   },
+  "accessKeyType": {
+    "message": "访问密钥格式"
+  },
   "clickToSet": {
     "message": "点此设置"
   },

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -9,6 +9,7 @@ export const defaultConfig = {
   rsshubDomain: "https://rsshub.app",
   rsshubAccessControl: {
     accessKey: "",
+    accessKeyType: "code",
   },
   notice: {
     badge: true,

--- a/src/options/routes/General.tsx
+++ b/src/options/routes/General.tsx
@@ -171,6 +171,43 @@ function General() {
                   "configurationRequiredIfAccessKeysEnabled",
                 )}
               />
+              {config.rsshubAccessControl.accessKey && (
+                <div className="flex items-center space-x-2">
+                  <Label>{chrome.i18n.getMessage("accessKeyType")}</Label>
+                  <div className="flex items-center space-x-4">
+                    <div className="flex items-center space-x-2">
+                      <input
+                        type="radio"
+                        id="accessKeyTypeCode"
+                        checked={config.rsshubAccessControl.accessKeyType === "code"}
+                        onChange={() =>
+                          setConfig({
+                            rsshubAccessControl: {
+                              accessKeyType: "code",
+                            },
+                          })
+                        }
+                      />
+                      <label htmlFor="accessKeyTypeCode">code={"{md5}"}</label>
+                    </div>
+                    <div className="flex items-center space-x-2">
+                      <input
+                        type="radio"
+                        id="accessKeyTypeKey"
+                        checked={config.rsshubAccessControl.accessKeyType === "key"}
+                        onChange={() =>
+                          setConfig({
+                            rsshubAccessControl: {
+                              accessKeyType: "key",
+                            },
+                          })
+                        }
+                      />
+                      <label htmlFor="accessKeyTypeKey">key={"{accessKey}"}</label>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
             <div className="grid w-full items-center gap-2">
               <Label htmlFor="remoteRulesUrl">

--- a/src/popup/RSSItem.tsx
+++ b/src/popup/RSSItem.tsx
@@ -38,7 +38,11 @@ function RSSItem({
   ).replace(/\/$/, "")
 
   if (type === "currentPageRSSHub" && config.rsshubAccessControl.accessKey) {
-    url = `${url}?code=${new MD5().update(item.path.replace(/\/$/, "") + config.rsshubAccessControl.accessKey).digest("hex")}`
+    if (config.rsshubAccessControl.accessKeyType === "key") {
+      url = `${url}?key=${config.rsshubAccessControl.accessKey}`
+    } else {
+      url = `${url}?code=${new MD5().update(item.path.replace(/\/$/, "") + config.rsshubAccessControl.accessKey).digest("hex")}`
+    }
   }
   if (type === "currentPageRSSHub") {
     item.title = item.title.replace(


### PR DESCRIPTION
## Overview

This PR introduces a new configuration option that allows users to customize the format of access key in generated RSSHub URLs:

- `code={md5}`: Original format using MD5 hash (default)
- `key={accessKey}`: Direct access key format

## Changes

- Added new configuration option `accessKeyType` in settings
- Updated UI to show radio buttons for selecting access key format
- Updated URL generation logic to support both formats
- Added translations for the new setting in English and Chinese

## Screenshot

![图片](https://github.com/user-attachments/assets/ae1fe346-10e1-452b-b262-7e4ffd4ce017)
