### PR TITLE
fix: exclude query params from auth

### DIFF
--- a/src/popup/RSSItem.tsx
+++ b/src/popup/RSSItem.tsx
@@ -38,11 +38,16 @@ function RSSItem({
   ).replace(/\/$/, "")
 
   if (type === "currentPageRSSHub" && config.rsshubAccessControl.accessKey) {
+    const urlObj = new URL(url)
+
     if (config.rsshubAccessControl.accessKeyType === "key") {
-      url = `${url}?key=${config.rsshubAccessControl.accessKey}`
+      urlObj.searchParams.append('key', config.rsshubAccessControl.accessKey)
     } else {
-      url = `${url}?code=${new MD5().update(item.path.replace(/\/$/, "") + config.rsshubAccessControl.accessKey).digest("hex")}`
+      const md5 = new MD5().update(urlObj.pathname + config.rsshubAccessControl.accessKey).digest("hex")
+      urlObj.searchParams.append('code', md5)
     }
+
+    url = urlObj.toString()
   }
   if (type === "currentPageRSSHub") {
     item.title = item.title.replace(


### PR DESCRIPTION
I added `limit=5` parameter in the radar configuration for syosetu route (https://github.com/DIYgod/RSSHub/pull/17500) to fetch Best 5 ranking entries, but found these parameters were incorrectly included in the authorization calculation.
Exmaple: `/syosetu/ranking/list/daily_total?limit=5?code=...`