### PR TITLE
fix: handle failed radar rules updates

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -134,6 +134,9 @@
   "updateSuccessful": {
     "message": "Update successful"
   },
+  "updateFailed": {
+    "message": "Update failed"
+  },
   "updateTip": {
     "message": "Automatically update every two hours, you can also manually update."
   },

--- a/public/_locales/zh_CN/messages.json
+++ b/public/_locales/zh_CN/messages.json
@@ -134,6 +134,9 @@
   "updateSuccessful": {
     "message": "更新成功"
   },
+  "updateFailed": {
+    "message": "更新失败"
+  },
   "updateTip": {
     "message": "每两小时自动更新一次，你也可以手动更新"
   },

--- a/src/background/messages/refreshRules.ts
+++ b/src/background/messages/refreshRules.ts
@@ -4,8 +4,21 @@ const handler = async (
   _message?: unknown,
   _sender?: chrome.runtime.MessageSender,
 ) => {
-  await refreshRules()
-  return true
+  try {
+    await refreshRules()
+    return {
+      success: true,
+    }
+  } catch (error) {
+    console.error(error)
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unknown error while refreshing rules",
+    }
+  }
 }
 
 export default handler

--- a/src/background/rules.ts
+++ b/src/background/rules.ts
@@ -30,9 +30,15 @@ export const getDisplayedRules = () => getLocalStorage("displayedRules")
 export const setDisplayedRules = (displayedRules) =>
   setLocalStorage("displayedRules", displayedRules)
 
+const refreshRulesSafely = () => {
+  refreshRules().catch((error) => {
+    console.error(error)
+  })
+}
+
 chrome.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === "refreshRulesAlarm") {
-    refreshRules()
+    refreshRulesSafely()
   }
 })
 
@@ -41,7 +47,7 @@ export async function initSchedule() {
   const rules = await getLocalStorage("rules")
   if (!rules) {
     setTimeout(() => {
-      refreshRules()
+      refreshRulesSafely()
     }, 60 * 1000)
   }
 

--- a/src/lib/rules.ts
+++ b/src/lib/rules.ts
@@ -1,21 +1,27 @@
 import _ from "lodash"
-
 import MD5 from "md5.js"
+
 import { getConfig } from "./config"
 import { defaultRules } from "./radar-rules"
 import type { Rules } from "./types"
 import { getRadarRulesUrl } from "./utils"
 
 export function parseRules(rules: string, forceJSON?: boolean) {
-  let incomeRules = rules
-  if (incomeRules) {
-    if (typeof rules === "string") {
-      try {
-        incomeRules = JSON.parse(rules)
-      } catch (error) {}
+  let incomeRules: unknown = rules
+
+  if (typeof rules === "string") {
+    try {
+      incomeRules = JSON.parse(rules)
+    } catch (error) {
+      incomeRules = forceJSON ? {} : rules
     }
   }
-  return _.mergeWith(defaultRules, incomeRules, (objValue, srcValue) => {
+
+  if (!_.isPlainObject(incomeRules)) {
+    incomeRules = {}
+  }
+
+  return _.mergeWith({}, defaultRules, incomeRules, (objValue, srcValue) => {
     if (_.isFunction(srcValue)) {
       return srcValue
     } else if (_.isFunction(objValue)) {
@@ -37,22 +43,34 @@ export function getRulesCount(rules: Rules) {
   return index
 }
 
-export function getRemoteRules() {
-  return new Promise<string>(async (resolve, reject) => {
-    const config = await getConfig()
-    try {
-      let url = getRadarRulesUrl(config.rsshubDomain)
-      
-      if (config.rsshubAccessControl.accessKey) {
-        const path = new URL(url).pathname
-        const code = new MD5().update(path + config.rsshubAccessControl.accessKey).digest("hex")
-        url = `${url}?code=${code}`
-      }
+export async function getRemoteRules() {
+  const config = await getConfig()
+  let url = getRadarRulesUrl(config.rsshubDomain)
 
-      const res = await fetch(url)
-      resolve(res.text())
-    } catch (error) {
-      reject(error)
-    }
-  })
+  if (config.rsshubAccessControl.accessKey) {
+    const path = new URL(url).pathname
+    const code = new MD5()
+      .update(path + config.rsshubAccessControl.accessKey)
+      .digest("hex")
+    url = `${url}?code=${code}`
+  }
+
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`Failed to fetch remote rules: ${res.status}`)
+  }
+
+  const text = await res.text()
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    throw new Error("Invalid remote rules response")
+  }
+
+  if (!_.isPlainObject(parsed)) {
+    throw new Error("Invalid remote rules payload")
+  }
+
+  return text
 }

--- a/src/options/routes/General.tsx
+++ b/src/options/routes/General.tsx
@@ -275,10 +275,30 @@ function General() {
                   setRulesUpdating(true)
                   sendToBackground({
                     name: "refreshRules",
-                  }).then((res) => {
-                    setRulesUpdating(false)
-                    toast.success(chrome.i18n.getMessage("updateSuccessful"))
                   })
+                    .then((res?: { success?: boolean; error?: string }) => {
+                      if (!res?.success) {
+                        toast.error(
+                          res?.error ||
+                            chrome.i18n.getMessage("updateFailed") ||
+                            "Update failed",
+                        )
+                        return
+                      }
+
+                      toast.success(chrome.i18n.getMessage("updateSuccessful"))
+                    })
+                    .catch((error: unknown) => {
+                      toast.error(
+                        error instanceof Error
+                          ? error.message
+                          : chrome.i18n.getMessage("updateFailed") ||
+                              "Update failed",
+                      )
+                    })
+                    .finally(() => {
+                      setRulesUpdating(false)
+                    })
                 }}
               >
                 {rulesUpdating && (


### PR DESCRIPTION
## Summary
- Validate remote radar rules fetch status and payload before writing to storage.
- Return structured success/error from background `refreshRules` message.
- Show failure toast on manual update and add `updateFailed` i18n messages.

## Impact
- Prevent 403/HTML responses from polluting local Radar Rules data.
- Stop false "Update successful" notifications when updates fail.

## Notes
- Wrap scheduled rules refresh with safe error handling.

## References / Links
- Repro: click **Manually update radar rules** → **Update Now** when `/api/radar/rules` returns 403.
