### PR TITLE
fix: use browser rss-parser for preview

### DIFF
--- a/src/tabs/preview.tsx
+++ b/src/tabs/preview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import Parser from "rss-parser"
+import Parser from "rss-parser/dist/rss-parser.min.js"
 
 import "~/lib/style.css"
 


### PR DESCRIPTION
## Why This Change
The preview page was importing rss-parser through its default package entry:
`import Parser from "rss-parser"` 
That entrypoint is oriented toward the Node/bundler path and can pull in code that is awkward in a browser extension page. In practice, the preview page was opening but rendering blank. rss-parser already ships a browser-targeted build in dist/, and its own [README recommends using that build for browser usage](https://github.com/rbren/rss-parser?tab=readme-ov-file#web). This change switches the preview page to that browser bundle instead:
`import Parser from "rss-parser/dist/rss-parser.min.js"`

Makes the extension from appearing like this at preview:
<img width="3700" height="2064" alt="image" src="https://github.com/user-attachments/assets/b44053b0-15a2-4aaf-93ab-ed8414180f8c" />
To this:
<img width="3664" height="2038" alt="image" src="https://github.com/user-attachments/assets/57f80402-a4c9-411e-a74a-c42054c6ac83" />

