### PR TITLE
chore(ci): upgrade actions to Node.js 24 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,20 +15,19 @@ jobs:
     runs-on: macos-latest
     name: Build assets
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Cache pnpm modules
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
-      - uses: pnpm/action-setup@v3.0.0
+      - uses: pnpm/action-setup@v6.0.10
         with:
-          version: latest
           run_install: true
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: 22.x
           cache: "pnpm"

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -17,20 +17,19 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Cache pnpm modules
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
-      - uses: pnpm/action-setup@v3.0.0
+      - uses: pnpm/action-setup@v6.0.10
         with:
-          version: latest
           run_install: true
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: 22.x
           cache: "pnpm"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,20 +13,19 @@ jobs:
     runs-on: macos-latest
     name: Build assets
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Cache pnpm modules
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-
-      - uses: pnpm/action-setup@v3.0.0
+      - uses: pnpm/action-setup@v6.0.10
         with:
-          version: latest
           run_install: true
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: 22.x
           cache: "pnpm"
@@ -37,7 +36,7 @@ jobs:
       - name: Package the extension for Safari
         run: pnpm build:safari:zip
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build
           path: |


### PR DESCRIPTION
## Why

[GitHub's Node.js 20 deprecation announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) states that Actions runners switched to Node.js 24 by default on June 16, 2026, and will remove Node.js 20 on September 23, 2026. The workflows still reference several action releases that use Node.js 20.

## What

- Upgrade checkout, cache, setup-node, pnpm setup, and artifact upload to their current Node.js 24 releases.
- Let pnpm setup use the `packageManager` version pinned in `package.json`, avoiding conflicting version declarations.
- Keep the build's Node.js 22 version, cache configuration, and release behavior unchanged.
